### PR TITLE
fix: handle ComfyUI Manager dependency restart in start.js

### DIFF
--- a/start.js
+++ b/start.js
@@ -4,7 +4,9 @@ module.exports = {
   },
   daemon: true,
   run: [
+    // [index 0] Start ComfyUI
     {
+      "id": "start_comfyui",
       method: "shell.run",
       params: {
         venv: "env",
@@ -20,6 +22,10 @@ module.exports = {
           "event": "/starting server.+(http:\/\/[a-zA-Z0-9.]+:[0-9]+)/i",
           "done": true
         }, {
+          // kill: true ensures ComfyUI is fully terminated before we jump back to restart after manager installs custom nodes
+          "event": "/\\[ComfyUI-Manager\\] Restarting to reapply dependency installation/",
+          "kill": true
+        }, {
           "event": "/errno/i",
           "break": false
         }, {
@@ -28,10 +34,43 @@ module.exports = {
         }]
       }
     },
+
+    // [index 1] Single conditional jump — routes to set_url on normal startup,
+    // or to manager_restart when Manager killed ComfyUI for dep installation.
+    // input.event[1] contains the URL on normal startup; absent on Manager restart.
+    // Pass the URL through jump params since jump resets input.
     {
+      method: "jump",
+      params: {
+        id: "{{input.event && input.event[1] ? 'set_url' : 'manager_restart'}}",
+        params: {
+          url: "{{input.event && input.event[1] ? input.event[1] : ''}}"
+        }
+      }
+    },
+
+    // [index 2] Manager restart path
+    {
+      "id": "manager_restart",
+      method: "notify",
+      params: {
+        html: "<b>✅ ComfyUI Manager installed new dependencies</b><br>Restarting ComfyUI to apply them — this will take a moment.",
+        type: "info"
+      }
+    },
+    {
+      method: "jump",
+      params: {
+        id: "start_comfyui"
+      }
+    },
+
+    // [index 4] Normal startup — set the URL for the Open WebUI button
+    {
+      "id": "set_url",
       method: "local.set",
       params: {
-        url: "{{input.event[1]}}"
+        url: "{{input.url}}"
       }
     }
   ]


### PR DESCRIPTION
This catches when the Manager tries and fails to restart Comfyui when directly spawning `python.exe main.py`.  

This is the required restart directly after the custom nodes are installed.  This fails in Pinokio and results in an ENOENT error requiring a 2nd manual restart.  Note that it's not the initial restart via the Manager UI restart button.  We still have to manually manage that one!

>  terminal message that fails currently:

```
[ComfyUI-Manager] Restarting to reapply dependency installation.

Command: ['"F:\\pinokio\\api\\comfy.git\\app\\env\\Scripts\\python.exe"', '"main.py"']
```

This PR uses `on: event` to capture that message. It kills the shell, and routes back to the start via the conditional `jump`. 
Otherwise the script continues through as per normal.  

We additionally retain the original `input.event`'s URL capture. As this doesn't travel though `jump`. 
